### PR TITLE
JAX v0.9.2 bump

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set python_min = "3.11" %}
 {% set name = "jax" %}
-{% set version = "0.9.1" %}
+{% set version = "0.9.2" %}
 
 package:
   name: jax
@@ -9,7 +9,7 @@ package:
 source:
   # Only pull source after PyPI release
   url: https://pypi.org/packages/source/j/jax/jax-{{ version }}.tar.gz
-  sha256: ce1b82477ee192f0b1d9801b095aa0cf3839bc1fe0cbc071c961a24b3ff30361
+  sha256: 42b28017b3e6b57a44b0274cc15f5153239c4873959030399ac1afc009c22365
 
 build:
   number: 0
@@ -30,7 +30,7 @@ requirements:
     - opt_einsum
     - scipy >=1.13
     # Change the minimum jaxlib version to _minimum_jaxlib_version in https://github.com/jax-ml/jax/blob/main/jax/version.py
-    - jaxlib >=0.9.1,<=0.9.1
+    - jaxlib >=0.9.2,<=0.9.2
   run_constrained:
     # Change to nvidia-cudnn-* in https://github.com/jax-ml/jax/blob/main/jax_plugins/cuda/plugin_setup.py
     - cudnn >=9.8,<10.0
@@ -44,7 +44,7 @@ test:
   requires:
     - pip
     # Change to test the declared minimum jaxlib version
-    - jaxlib ==0.9.1
+    - jaxlib ==0.9.2
     - python {{ python_min }}
 
 about:


### PR DESCRIPTION
autotick failed to also bump the test requirement in gh-188

